### PR TITLE
Reflect the ToolbarItem enabled state

### DIFF
--- a/iOSSecondaryToolbarMenubar/iOSSecondaryToolbarMenubar/iOSSecondaryToolbarMenubar.iOS/Services/TableSource.cs
+++ b/iOSSecondaryToolbarMenubar/iOSSecondaryToolbarMenubar/iOSSecondaryToolbarMenubar.iOS/Services/TableSource.cs
@@ -34,6 +34,8 @@ namespace iOSSecondaryToolbarMenubar.iOS.Services
 			if (cell == null)
 			{ cell = new UITableViewCell(UITableViewCellStyle.Default, CellIdentifier); }
 			cell.TextLabel.Text = item;
+			cell.UserInteractionEnabled = _tableItems[indexPath.Row].IsEnabled;
+			cell.TextLabel.Enabled = cell.UserInteractionEnabled;
 			return cell;
 		}
 


### PR DESCRIPTION
In order to reflect the active/inactive state of a ToolbarItem element, especially if it is bound to a Command, the ```GetCell``` function should be modified in the ```TableSource``` class.